### PR TITLE
Add flowtype plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,13 @@
 module.exports = {
   "parser": "babel-eslint",
-  "extends": "standard",
-  "plugins": [
+  "extends": [
+    "plugin:flowtype/recommended",
     "standard",
-    "promise"
+  ],
+  "plugins": [
+    "flowtype",
+    "standard",
+    "promise",
   ],
   "rules": {
     "comma-style": [ "error", "first" ],
@@ -11,5 +15,15 @@ module.exports = {
     // We put exports first
     "import/first": 0,
     "no-use-before-define": 0,
+    "flowtype/type-id-match": [
+      2,
+      // Only enforce that it starts with a capital letter
+      "^[A-Z][a-z0-9]*"
+    ],
+    "flowtype/require-valid-file-annotation": [
+      2,
+      "always",
+      { "annotationStyle": "line" }
+    ]
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-influential",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "dependencies": {
     "acorn": {
@@ -252,6 +252,12 @@
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz",
       "integrity": "sha1-wGHk0GbzedwXzVYsZOgZtN1FRZE=",
+      "dev": true
+    },
+    "eslint-plugin-flowtype": {
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.35.0.tgz",
+      "integrity": "sha512-zjXGjOsHds8b84C0Ad3VViKh+sUA9PeXKHwPRlSLwwSX0v1iUJf/6IX7wxc+w2T2tnDH8PT6B/YgtcEuNI3ssA==",
       "dev": true
     },
     "espree": {

--- a/package.json
+++ b/package.json
@@ -20,11 +20,13 @@
   "peerDependencies": {
     "babel-eslint": "^7.2.3",
     "eslint": ">=3",
-    "eslint-config-standard": "^10.2.1"
+    "eslint-config-standard": "^10.2.1",
+    "eslint-plugin-flowtype": "^2.35.0"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",
     "eslint": "^3.5.0",
-    "eslint-config-standard": "^10.2.1"
+    "eslint-config-standard": "^10.2.1",
+    "eslint-plugin-flowtype": "^2.35.0"
   }
 }


### PR DESCRIPTION
For projects that aren't using flow yet, we're going to need to override `flowtype/require-valid-file-annotation` in the local config. But I wanted enforcing it to be the default for new projects.