### PR TITLE
Enable new-cap warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ module.exports = {
   ],
   'rules': {
     'arrow-parens': ['error', 'always'],
+    'new-cap': [ 'warn', {
+      'capIsNew': true,
+    } ],
     'camelcase': 0,
     'comma-dangle': [ 'error', 'always-multiline' ],
     'flowtype/require-valid-file-annotation': [


### PR DESCRIPTION
Only constructor functions and classes should be captitalized. This rule is
configured to warn on: `SomeFunction()` and `new someFunction()`.

This will help us avoid name conflicts between Flow types and functions. 

Normally my philosophy is that everything should be an error, but I think this may cause too many errors in too many projects to be an error.